### PR TITLE
Adding patch ability to qhub generated repository allowing for arbitray customization to configuration

### DIFF
--- a/qhub/render/__init__.py
+++ b/qhub/render/__init__.py
@@ -101,6 +101,7 @@ def render_template(
         with filename.open() as f:
             config = yaml.safe_load(f)
             config["repo_directory"] = repo_directory
+            config["run_directory"] = pathlib.Path.cwd()
             patch_dask_gateway_extra_config(config)
 
         with (input_directory / "cookiecutter.json").open() as f:

--- a/qhub/template/cookiecutter.json
+++ b/qhub/template/cookiecutter.json
@@ -10,6 +10,7 @@
     "profiles": null,
     "environments": null,
     "storage": null,
+    "patches": [],
 
     "digital_ocean": {
         "region": null,

--- a/qhub/template/hooks/post_gen_project.py
+++ b/qhub/template/hooks/post_gen_project.py
@@ -1,9 +1,12 @@
 import os
 import yaml
+import subprocess
 
 PROJECT_DIRECTORY = os.path.realpath(os.path.curdir)
 PROVIDER = "{{ cookiecutter.provider }}"
 ENVIRONMENTS = eval("{{ cookiecutter.environments }}")
+PATCHES = eval("{{ cookiecutter.patches }}")
+RUN_DIRECTORY = "{{ cookiecutter.run_directory }}"
 
 
 def remove_file(filepath):
@@ -11,12 +14,14 @@ def remove_file(filepath):
 
 
 if __name__ == "__main__":
+    # Add environments to repository
     if ENVIRONMENTS:
         os.makedirs("environments", exist_ok=True)
         for name, spec in ENVIRONMENTS.items():
             with open(f"environments/{name}", "w") as f:
                 yaml.dump(spec, f)
 
+    # Remove terraform code for unused providers
     if PROVIDER == "aws":
         remove_file("infrastructure/do.tf")
         remove_file("infrastructure/gcp.tf")
@@ -26,3 +31,14 @@ if __name__ == "__main__":
     elif PROVIDER == "gcp":
         remove_file("infrastructure/aws.tf")
         remove_file("infrastructure/do.tf")
+
+    # Last but not least apply patches
+    # git apply <patch-name> generating patch files is in
+    # documentation
+    for patch_filename in PATCHES:
+        absolute_patch_filename = (
+            patch_filename
+            if os.path.isabs(patch_filename)
+            else os.path.join(RUN_DIRECTORY, patch_filename)
+        )
+        subprocess.check_output(["git", "apply", absolute_patch_filename])

--- a/shell.nix
+++ b/shell.nix
@@ -31,18 +31,4 @@ pkgs.mkShell {
     # distribute
     pythonPackages.twine
   ];
-
-  shellHook = ''
-    export CLOUDFLARE_TOKEN=$(gopass www/cloudflare.com/qhub@quansight.com token-qhub-dev-edit)
-    export AUTH0_DOMAIN=$(gopass www/auth0.com/qhub@quansight.com domain)
-    export AUTH0_CLIENT_ID=$(gopass www/auth0.com/qhub@quansight.com client_id)
-    export AUTH0_CLIENT_SECRET=$(gopass www/auth0.com/qhub@quansight.com client_secret)
-
-    export AWS_ACCESS_KEY_ID=$(gopass www/digitalocean.com/costrouchov@quansight.com qhub-terraform-state-spaces-access-key)
-    export SPACES_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
-    export AWS_SECRET_ACCESS_KEY=$(gopass www/digitalocean.com/costrouchov@quansight.com qhub-terraform-state-spaces-secret-key)
-    export SPACES_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
-    export DIGITALOCEAN_TOKEN=$(gopass www/digitalocean.com/costrouchov@quansight.com qhub-terraform)
-    doctl kubernetes cluster kubeconfig save do-jupyterhub-dev
-  '';
 }

--- a/tests/assets/config_do_patch.yaml
+++ b/tests/assets/config_do_patch.yaml
@@ -1,0 +1,144 @@
+project_name: do-jupyterhub
+provider: do
+ci_cd: github-actions
+domain: "do.qhub.dev"
+
+security:
+  authentication:
+    type: GitHub
+    config:
+      client_id: CLIENT_ID
+      client_secret: CLIENT_SECRET
+      oauth_callback_url: https://jupyter.do.qhub.dev/hub/oauth_callback
+  users:
+    costrouc:
+      uid: 1000
+      primary_group: users
+      secondary_groups:
+        - billing
+    dharhas:
+      uid: 1001
+      primary_group: admin
+    tonyfast:
+      uid: 1002
+      primary_group: admin
+    prasunanand:
+      uid: 1003
+      primary_group: admin
+    aktech:
+      uid: 1004
+      primary_group: users
+      secondary_groups:
+        - admin
+  groups:
+    users:
+      gid: 100
+    admin:
+      gid: 101
+    billing:
+      gid: 102
+
+
+digital_ocean:
+  region: nyc3
+  kubernetes_version: "1.16.6-do.2"
+  node_groups:
+    general:
+      instance: "s-2vcpu-4gb"
+      min_nodes: 1
+      max_nodes: 1
+    user:
+      instance: "s-2vcpu-4gb"
+      min_nodes: 1
+      max_nodes: 4
+    worker:
+      instance: "s-2vcpu-4gb"
+      min_nodes: 1
+      max_nodes: 4
+
+
+default_images:
+  jupyterhub: "quansight/qhub-jupyterhub:4c8c28332be1fde32f786c54a5961b5f3d789e16"
+  jupyterlab: "quansight/qhub-jupyterlab:4c8c28332be1fde32f786c54a5961b5f3d789e16"
+  dask_worker: "quansight/qhub-dask-worker:4c8c28332be1fde32f786c54a5961b5f3d789e16"
+
+
+storage:
+  conda_store: 20Gi
+  shared_filesystem: 10Gi
+
+
+profiles:
+  jupyterlab:
+    - display_name: Small Instance
+      description: Stable environment with 1 cpu / 1 GB ram
+      groups:
+        - admin
+      kubespawner_override:
+        cpu_limit: 1
+        cpu_guarantee: 1
+        mem_limit: 1G
+        mem_guarantee: 1G
+        image: "quansight/qhub-jupyterlab:4c8c28332be1fde32f786c54a5961b5f3d789e16"
+    - display_name: Medium Instance
+      description: Stable environment with 1.5 cpu / 2 GB ram
+      default: true
+      kubespawner_override:
+        cpu_limit: 1.5
+        cpu_guarantee: 1.25
+        mem_limit: 2G
+        mem_guarantee: 2G
+        image: "quansight/qhub-jupyterlab:4c8c28332be1fde32f786c54a5961b5f3d789e16"
+
+  dask_worker:
+    "Small Worker":
+      worker_cores_limit: 1
+      worker_cores: 1
+      worker_memory_limit: 1G
+      worker_memory: 1G
+      image: "quansight/qhub-dask-worker:4c8c28332be1fde32f786c54a5961b5f3d789e16"
+    "Medium Worker":
+      worker_cores_limit: 1.5
+      worker_cores: 1.25
+      worker_memory_limit: 2G
+      worker_memory: 2G
+      image: "quansight/qhub-dask-worker:4c8c28332be1fde32f786c54a5961b5f3d789e16"
+
+
+environments:
+  "environment-default.yaml":
+    name: default
+    channels:
+      - conda-forge
+      - defaults
+    dependencies:
+      - python=3.7
+      - ipykernel
+      - ipywidgets
+      - dask==2.14.0
+      - distributed==2.14.0
+      - dask-gateway=0.6.1
+      - numpy
+      - numba
+      - pandas
+
+  "environment-example-2.yaml":
+    name: example-2
+    channels:
+      - conda-forge
+      - defaults
+    dependencies:
+      - python=3.7
+      - ipykernel
+      - ipywidgets
+      - dask==2.14.0
+      - distributed==2.14.0
+      - dask-gateway=0.6.1
+      - numpy
+      - numba
+      - pandas
+      - jinja2
+      - pyyaml
+
+patches:
+ - tests/assets/patches/do-example.patch

--- a/tests/assets/patches/do-example.patch
+++ b/tests/assets/patches/do-example.patch
@@ -1,0 +1,39 @@
+diff --git a/infrastructure/do.tf b/infrastructure/do.tf
+index 5284b90..9f12a42 100644
+--- a/infrastructure/do.tf
++++ b/infrastructure/do.tf
+@@ -7,7 +7,7 @@ module "kubernetes" {
+   name = local.cluster_name
+ 
+   region             = var.region
+-  kubernetes_version = "1.16.6-do.2"
++  kubernetes_version = "this-s-not-a-version"
+ 
+   node_groups = [
+ 
+diff --git a/infrastructure/kubernetes.tf b/infrastructure/kubernetes.tf
+index 762d937..61bfaf4 100644
+--- a/infrastructure/kubernetes.tf
++++ b/infrastructure/kubernetes.tf
+@@ -21,7 +21,7 @@ module "kubernetes-nfs-server" {
+ 
+   name         = "nfs-server"
+   namespace    = var.environment
+-  nfs_capacity = "10Gi"
++  nfs_capacity = "99999999Gi"
+ }
+ 
+ module "kubernetes-nfs-mount" {
+diff --git a/infrastructure/variables.tf b/infrastructure/variables.tf
+index 5a0201d..3672cdb 100644
+--- a/infrastructure/variables.tf
++++ b/infrastructure/variables.tf
+@@ -11,7 +11,7 @@ variable "environment" {
+ 
+ variable "region" {
+   type    = string
+-  default = "nyc3"
++  default = "not-a-region"
+ }
+ # jupyterhub
+ variable "endpoint" {

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -3,12 +3,16 @@ import pytest
 from qhub.render import render_default_template
 
 
-@pytest.mark.parametrize('config_filename', [
-    'tests/assets/config_aws.yaml',
-    'tests/assets/config_gcp.yaml',
-    'tests/assets/config_do.yaml',
-])
+@pytest.mark.parametrize(
+    "config_filename",
+    [
+        "tests/assets/config_aws.yaml",
+        "tests/assets/config_gcp.yaml",
+        "tests/assets/config_do.yaml",
+        "tests/assets/config_do_patch.yaml",
+    ],
+)
 def test_render(config_filename, tmp_path):
-    output_directory = tmp_path / 'test'
+    output_directory = tmp_path / "test"
 
     render_default_template(str(output_directory), config_filename)


### PR DESCRIPTION
This is a solution to address https://github.com/Quansight/qhub/issues/58. This works by generating the repository like normal from `qhub-ops-config.yaml` and then applying an arbitrary number of `git apply <patch-filename>` to repository. This will allow any customization to the repositiory. Also since patches can apply to multiple files in a single patch we can have well named patches e.g. "add-prefect-shorterm-fix.patch" etc. Also another benifit of patches is that they will complain if the code it is patching changes too much making. For an example see `tests/assets/config_do_patch.yaml`. There is a pytest test to ensure this works.

# How to create a git patch

https://nithinbekal.com/posts/git-patch/ start with nothing staged in the directory

```
# add the files that you changed
git add <files>
# create a patch from these changes `patches/<patch-name>.patch` is a good directory/filename
git diff --cached > <patch-filename>
# add the patch filename to `qhub-ops-config.yaml` under the list of top level key `patches`
```

The benefit of this approach is that it completely covers the complex use case, is reasonably hard to do creating an intentional barrier to entry for this feature.