### PR TITLE
Remove the unsupported argument for k8s provider

### DIFF
--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/kubernetes.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/kubernetes.tf
@@ -1,5 +1,4 @@
 provider "kubernetes" {
-  load_config_file       = false
   host                   = module.kubernetes.credentials.endpoint
   token                  = module.kubernetes.credentials.token
   cluster_ca_certificate = module.kubernetes.credentials.cluster_ca_certificate


### PR DESCRIPTION
Fixes #261 

See this: https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/guides/v2-upgrade-guide#changes-to-kubernetes-credentials-supplied-in-the-provider-block