### PR TITLE
Remove registry for DigitalOcean

### DIFF
--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/do.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/do.tf
@@ -1,10 +1,5 @@
 provider "digitalocean" {}
 
-module "registry" {
-  source = "github.com/quansight/qhub-terraform-modules//modules/digitalocean/registry"
-  name   = "{{ cookiecutter.project_name }}"
-}
-
 
 module "kubernetes" {
   source = "github.com/quansight/qhub-terraform-modules//modules/digitalocean/kubernetes"


### PR DESCRIPTION
Since this is unused. I have not removed the GCP/AWS ones at the moment, since they are not causing any problems (happy to remove them as well, if people think so).

The problem is following by the way:

I realised that one can create only one registry per DigitalOcean account:

Now when I try to create a registry, I get:
Error: Error creating container registry: POST https://api.digitalocean.com/v2/registry: 422 user already has a registry

Which makes sense, but when I enter the name of the repository for creation, instead of returning the already existing repository, it gives me the following error:
Error: Error creating container registry: POST https://api.digitalocean.com/v2/registry: 409 name already exists

Terraform docs: https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/container_registry