### PR TITLE
Fix prefect cookiecutter check

### DIFF
--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/variables.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/variables.tf
@@ -86,7 +86,7 @@ variable "dask-worker-image" {
   }
 }
 
-{%- if cookiecutter.prefect is defined %}
+{% if cookiecutter.prefect is true -%}
 variable "prefect_token" {
   type = string
 }


### PR DESCRIPTION
Fixes #286 

The jinja boolean check syntax was wrong. This fixes it.