### PR TITLE
Remove `costrouc` as the default user in qhub

### DIFF
--- a/docs/source/02_get_started/04_configuration.md
+++ b/docs/source/02_get_started/04_configuration.md
@@ -37,7 +37,7 @@ security:
       client_secret: <CLIENT_SECRET>
       oauth_callback_url: https://jupyter.do.qhub.dev/hub/oauth_callback
   users:
-    costrouc:
+    example-user:
       uid: 1000
       primary_group: users
       secondary_groups:
@@ -228,7 +228,7 @@ profiles:
     - display_name: Small Instance
       description: Stable environment with 1 cpu / 1 GB ram
       users:
-        - costrouc
+        - example-user
       groups:
         - admin
       default: true
@@ -342,7 +342,7 @@ security:
       client_secret: CLIENT_SECRET
       oauth_callback_url: https://jupyter.do.qhub.dev/hub/oauth_callback
   users:
-    costrouc:
+    example-user:
       uid: 1000
       primary_group: users
       secondary_groups:

--- a/docs/source/06_developers_contrib_guide/04_local_development.md
+++ b/docs/source/06_developers_contrib_guide/04_local_development.md
@@ -130,7 +130,7 @@ the users section shown like below.
 
 ```
   users:
-    costrouc:
+    example-user:
       uid: 1000
       ...
       password: '$2b$12$VsGc2HK1HF0o.8eJGHLlDenkseUf6B1pxizxgAN6/elR.ZaX8u0OG'

--- a/docs/source/06_developers_contrib_guide/04_local_development.md
+++ b/docs/source/06_developers_contrib_guide/04_local_development.md
@@ -122,7 +122,7 @@ python -m qhub init local --project=thisisatest  --domain github-actions.qhub.de
 ```
 
 Give a password to the default user. For this the example password is
-`<password>`. You can generate your own via `python -c "import bcrypt;
+`example-user`. You can generate your own via `python -c "import bcrypt;
 bcrypt.hashpw(b'<password>', bcrypt.gensalt())"`. Where you can change
 `<password>` to be the password you want. This requires the bcrypt python 
 package to be installed. This must be added to the `qhub-config.yaml` in 
@@ -133,7 +133,7 @@ the users section shown like below.
     example-user:
       uid: 1000
       ...
-      password: '$2b$12$VsGc2HK1HF0o.8eJGHLlDenkseUf6B1pxizxgAN6/elR.ZaX8u0OG'
+      password: '$2b$12$lAk2Bhw8mu0QJkSecPiABOX2m87RF8N7vv7rBw9JksOgewI2thUuO'
       ...
       primary_group: users
 

--- a/qhub/initialize.py
+++ b/qhub/initialize.py
@@ -20,7 +20,7 @@ BASE_CONFIGURATION = {
     "security": {
         "authentication": None,
         "users": {
-            "costrouc": {
+            "example-user": {
                 "uid": 1000,
                 "primary_group": "users",
                 "secondary_groups": ["admin"],


### PR DESCRIPTION
To follow the standard default username we currently use in onprem, the original `costrouc` was modified to `example-user` as well as it's correlated mentions in the docs. The default password fingerprint in the [docs](https://github.com/Quansight/qhub-cloud/blob/dev/docs/source/06_developers_contrib_guide/04_local_development.md#initialize-kubernetes-cluster) was also modified to match the default username.



#349 