### PR TITLE
Generate a random password for example-user

### DIFF
--- a/qhub/cli/deploy.py
+++ b/qhub/cli/deploy.py
@@ -22,7 +22,7 @@ def create_deploy_subcommand(subparser):
         help="Attempt to automatically provision DNS. For Auth0 is requires environment variables AUTH0_DOMAIN, AUTH0_CLIENTID, AUTH0_CLIENT_SECRET",
     )
     subparser.add_argument(
-        "--disable-prompt", action="store_true", help="Disable human intervention",
+        "--disable-prompt", action="store_true", help="Disable human intervention"
     )
     subparser.set_defaults(func=handle_deploy)
 

--- a/qhub/initialize.py
+++ b/qhub/initialize.py
@@ -1,6 +1,9 @@
 import os
 import re
+import string
+import random
 
+import bcrypt
 import requests
 
 from qhub.provider.oauth.auth0 import create_client
@@ -233,10 +236,13 @@ def render_config(
         config["security"]["authentication"] = AUTH_PASSWORD
 
         # Generate a random password
-        import bcrypt, string, random
-        example_password = ''.join(random.choice(string.ascii_letters+string.digits) for i in range(16))
-        config["security"]["users"]["example-user"]["password"] = bcrypt.hashpw(example_password.encode('utf-8'), bcrypt.gensalt()).decode()
-        print(f'Your QHub password for example-user is {example_password}')
+        example_password = "".join(
+            random.choice(string.ascii_letters + string.digits) for i in range(16)
+        )
+        config["security"]["users"]["example-user"]["password"] = bcrypt.hashpw(
+            example_password.encode("utf-8"), bcrypt.gensalt()
+        ).decode()
+        print(f"Your QHub password for example-user is {example_password}")
 
     if cloud_provider == "do":
         config["theme"]["jupyterhub"][

--- a/qhub/initialize.py
+++ b/qhub/initialize.py
@@ -232,6 +232,12 @@ def render_config(
     elif auth_provider == "password":
         config["security"]["authentication"] = AUTH_PASSWORD
 
+        # Generate a random password
+        import bcrypt, string, random
+        example_password = ''.join(random.choice(string.ascii_letters+string.digits) for i in range(16))
+        config["security"]["users"]["example-user"]["password"] = bcrypt.hashpw(example_password.encode('utf-8'), bcrypt.gensalt()).decode()
+        print(f'Your QHub password for example-user is {example_password}')
+
     if cloud_provider == "do":
         config["theme"]["jupyterhub"][
             "hub_subtitle"

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         "auth0-python",
         "pydantic",
         "pynacl",
+        "bcrypt",
     ],
     extras_require={"dev": ["flake8==3.8.3", "black==19.10b0", "twine", "pytest", "diagrams"]},
     include_package_data=True,


### PR DESCRIPTION
During qhub init if auth type is password, generates a random password and prints:
`Your QHub password for example-user is {example_password}`

Closes #414

