### PR TITLE
Render by default in the deploy command of qhub

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -143,10 +143,6 @@ jobs:
           cd local-deployment
           qhub init local --project=thisisatest  --domain github-actions.qhub.dev --auth-provider=password --terraform-state=local
           cat qhub-config.yaml
-      - name: Render QHub Cloud
-        run: |
-          cd local-deployment
-          qhub render --config qhub-config.yaml -f
       - name: Deploy QHub Cloud
         run: |
           cd local-deployment

--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ Once all the necessary credentials are gathered and set as [UNIX environment var
 QHub can be deployed in under 20 minutes using:
 ```bash
 qhub init   ... # generates initial config file and optionally automates deployment steps
-qhub render ... # creates the Terraform config module
 qhub deploy ... # creates and configures the cloud infrastructure
 ```
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,6 +12,7 @@
 
 ### Feature changes and enhancements
 * Terraform binary is auto-installed and version managed by qhub
+* Deploy stage will auto render by default removing the need for render command for end users
 * Full JupyterHub theming including colors now.
 * JupyterHub docker image now independent from zero-to-jupyterhub.
 * JupyterLab 3 now default user Docker image.

--- a/docs/source/02_get_started/03_usage.md
+++ b/docs/source/02_get_started/03_usage.md
@@ -38,34 +38,25 @@ There are several **optional** (yet highly recommended) flags that allow to conf
 - `--auth-auto-provision`: This will automatically create and configure an application using OAuth.
 - `--repository`: Repository name that will be used to store the Infrastructure-as-Code on GitHub.
 - `--repository-auto-provision`: Sets the secrets for the GitHub repository used for CI/CD actions.
+        
+### Deploy QHub
 
-
-### Render config files
-This file will handle the creation of all Terraform modules for the QHub infrastructure.
-
-After initializing, we then need to create all Terraform configuration. This done by running the local command:
+Finally, we can deploy QHub with:
 ```shell
-qhub render -c qhub-config.yaml -o ./ -f
+qhub deploy -c qhub-config.yaml -f --dns-provider cloudflare --dns-auto-provision
 ```
 
 This will create the following folder structure:
+
 ```
 .
 ├── environments        # stores the conda environments
 ├── image               # docker images used on deployment: jupyterhub, jupyterlab, and dask-gateway
 │   ├── dask-worker
 │   ├── jupyterlab
-│   │   └── __pycache__
 │   └── scripts
 ├── infrastructure      # contains Terraform files that declare state of infrastructure
 └── terraform-state     # required by terraform to securely store the state of the deployment
-```
-        
-### Deploy QHub
-
-Finally, we can deploy QHub with:
-```shell
-qhub deploy -c qhub-config.yaml --dns-provider cloudflare --dns-auto-provision
 ```
 
 The terminal will prompt to press `[enter]` to check auth credentials (which were added by the `qhub init` command). 

--- a/docs/source/02_get_started/03_usage.md
+++ b/docs/source/02_get_started/03_usage.md
@@ -43,7 +43,7 @@ There are several **optional** (yet highly recommended) flags that allow to conf
 
 Finally, we can deploy QHub with:
 ```shell
-qhub deploy -c qhub-config.yaml -f --dns-provider cloudflare --dns-auto-provision
+qhub deploy -c qhub-config.yaml --dns-provider cloudflare --dns-auto-provision
 ```
 
 This will create the following folder structure:

--- a/docs/source/02_get_started/04_configuration.md
+++ b/docs/source/02_get_started/04_configuration.md
@@ -522,7 +522,7 @@ environments:
 
 ```shell
 pip install qhub-ops
-qhub-ops render -c qhub-config.yaml -o ./ -f
+qhub render -c qhub-config.yaml
 ```
 This will initialize the repository and next proceed to
 installation. Do not commit to repo to GitHub until you have

--- a/docs/source/03_tutorials_and_samples/1_project_setup_tutorial.md
+++ b/docs/source/03_tutorials_and_samples/1_project_setup_tutorial.md
@@ -130,23 +130,17 @@ Best practices is to create a new directory and run all the qhub commands inside
 
 `qhub init gcp --project test-project --domain test.qhub.dev --ci-provider github-actions --auth-provider auth0 --auth-auto-provision --repository github.com/quansight/qhub-test --repository-auto-provision`
 
-### 2.6 QHub render
+### 2.6 QHub deploy
 
-After initializing, we then need to create all of Terraform configuration. This done by running the local command:
+Finally we can deploy with:
 
-        qhub render -c qhub-config.yaml -o ./ -f
-        
+    qhub deploy -c qhub-config.yaml --dns-provider cloudflare --dns-auto-provision
+
 You will notice that several directories are created: 
   - `environments` : conda environments are stored
   - `infrastructure` : terraform files that declare state of infrastructure
   - `terraform-state` : required by terraform to securely store the state of the Terraform deployment
   - `image` : docker images used in QHub deployment including: jupyterhub, jupyterlab, and dask-gateway
-        
-### 2.7 QHub deploy
-
-Finally we can deploy with:
-
-    qhub deploy -c qhub-config.yaml --dns-provider cloudflare --dns-auto-provision
 
 The terminal will prompt to press `[enter]` to check oauth credentials (which were added by qhub init). After pressing `enter` the deployment will continue and take roughly 10 minutes. Part of the output will show an "ip" address (DO/GCP) or a CNAME "hostname" (AWS) based on the the cloud service provider:
 
@@ -168,7 +162,7 @@ The terminal will prompt to press `[enter]` to check oauth credentials (which we
         }
 
         
-### 2.8 Push repository
+### 2.7 Push repository
 
 Add all files to github:
 

--- a/docs/source/06_developers_contrib_guide/04_tests.md
+++ b/docs/source/06_developers_contrib_guide/04_tests.md
@@ -212,11 +212,7 @@ the users section shown like below.
 
 ```
 
-Render the files from the `qhub-config.yaml`
-
-```shell
-python -m qhub render --config qhub-config.yaml -f
-```
+Deploy and render the infrastructure
 
 ```shell
 python -m qhub deploy --config qhub-config.yaml --disable-prompt

--- a/qhub/cli/deploy.py
+++ b/qhub/cli/deploy.py
@@ -30,7 +30,9 @@ def create_deploy_subcommand(subparser):
         help="Disable human intervention",
     )
     subparser.add_argument(
-        "--disable-render", action="store_true", help="Disable auto-rendering in deploy stage"
+        "--disable-render",
+        action="store_true",
+        help="Disable auto-rendering in deploy stage",
     )
     subparser.set_defaults(func=handle_deploy)
 

--- a/qhub/cli/deploy.py
+++ b/qhub/cli/deploy.py
@@ -4,6 +4,7 @@ import logging
 
 from qhub.deploy import deploy_configuration
 from qhub.schema import verify
+from qhub.render import render_default_template, render_template
 
 logger = logging.getLogger(__name__)
 
@@ -11,6 +12,8 @@ logger = logging.getLogger(__name__)
 def create_deploy_subcommand(subparser):
     subparser = subparser.add_parser("deploy")
     subparser.add_argument("-c", "--config", help="qhub configuration", required=True)
+    subparser.add_argument("-i", "--input", help="input directory")
+    subparser.add_argument("-o", "--output", default="./", help="output directory")
     subparser.add_argument(
         "--dns-provider",
         choices=["cloudflare"],
@@ -26,6 +29,9 @@ def create_deploy_subcommand(subparser):
         action="store_true",
         help="Disable human intervention",
     )
+    subparser.add_argument(
+        "--disable-render", action="store_true", help="Disable auto-rendering in deploy stage"
+    )
     subparser.set_defaults(func=handle_deploy)
 
 
@@ -40,6 +46,12 @@ def handle_deploy(args):
         config = yaml.safe_load(f.read())
 
     verify(config)
+
+    if not args.disable_render:
+        if args.input is None:
+            render_default_template(args.output, args.config, force=True)
+        else:
+            render_template(args.input, args.output, args.config, force=True)
 
     deploy_configuration(
         config, args.dns_provider, args.dns_auto_provision, args.disable_prompt

--- a/qhub/cli/render.py
+++ b/qhub/cli/render.py
@@ -5,9 +5,6 @@ from qhub.schema import verify
 def create_render_subcommand(subparser):
     subparser = subparser.add_parser("render")
     subparser.add_argument("-i", "--input", help="input directory")
-    subparser.add_argument(
-        "-f", "--force", action="store_true", help="overwrite existing files"
-    )
     subparser.add_argument("-o", "--output", default="./", help="output directory")
     subparser.add_argument("-c", "--config", help="cookiecutter configuration")
     subparser.set_defaults(func=handle_render)
@@ -29,6 +26,6 @@ def handle_render(args):
     verify(config)
 
     if args.input is None:
-        render_default_template(args.output, args.config, force=args.force)
+        render_default_template(args.output, args.config, force=True)
     else:
-        render_template(args.input, args.output, args.config, force=args.force)
+        render_template(args.input, args.output, args.config, force=True)

--- a/qhub/template/{{ cookiecutter.repo_directory }}/.github/workflows/qhub-ops.yaml
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/.github/workflows/qhub-ops.yaml
@@ -25,7 +25,7 @@ jobs:
           pip install qhub==0.2.3
       - name: Render Changes to Template
         run: |
-          qhub render -c qhub-config.yaml -o ./ -f
+          qhub render -c qhub-config.yaml
       - name: Push Changes
         run: |
           git config user.email "qhub@quansight.com"


### PR DESCRIPTION
There are two main motivations for the move:
   - simplify the instructions for getting started with qhub
   - often times users forget to render before a deploy when modifying the `qhub-config.yaml`

Closes https://github.com/Quansight/qhub-cloud/issues/413