### PR TITLE
FIXUP: Forgot part of jupyterhub_config when moving towards templates

### DIFF
--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/jupyterhub.yaml
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/jupyterhub.yaml
@@ -24,7 +24,7 @@ hub:
     AUTH0_SUBDOMAIN: "{{ cookiecutter.security.authentication.config.auth0_subdomain }}"
 {% endif %}
   extraConfig:
-    jupyterhub_config: |
+    jupyterhub_extra_config: |
 {% filter indent(width=6) %}
 {% include "templates/jupyterhub_config.py.j2" %}
 {% endfilter %}

--- a/qhub/template/{{ cookiecutter.repo_directory }}/templates/jupyterhub_config.py.j2
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/templates/jupyterhub_config.py.j2
@@ -130,6 +130,15 @@ c.JupyterHub.admin_access = True
 c.Authenticator.admin_users = qhub_list_admins(QHUB_USER_MAPPING)
 c.Authenticator.whitelist = qhub_list_users(QHUB_USER_MAPPING)
 
+async def custom_options_form(self):
+     self.profile_list = qhub_list_available_profiles(self.user.name)
+
+     # Let KubeSpawner inspect profile_list and decide what to return
+     return self._options_form_default()
+
+c.KubeSpawner.options_form = custom_options_form
+c.LocalProcessSpawner.shell_cmd = ['bash', '-l', '-c']
+
 {% if cookiecutter.security.authentication.type == 'password' %}
 # ==================== AUTHENTICATION ======================
 # create passwords via


### PR DESCRIPTION
These were the forgotten lines
https://github.com/Quansight/qhub-cloud/blob/7f7e8b43a3be46a40bae01c03d76bb3145119540/qhub/template/%7B%7B%20cookiecutter.repo_directory%20%7D%7D/infrastructure/jupyterhub.yaml#L143-L151

Closes https://github.com/Quansight/qhub-cloud/issues/370

Closes https://github.com/Quansight/qhub-cloud/issues/393